### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ g++ -O3 -o train train.cpp # コンパイル
 $ ./train -t 0.001 -n 10000 features.txt model # 学習
 ```
 
-きちんと分割できるが実際に試してみます．
+きちんと分割できるか実際に試してみます．
 
 ``` bash
 $ ./segment model

--- a/Segmenter.py
+++ b/Segmenter.py
@@ -5,7 +5,7 @@ import re
 
 class Segmenter(object):
     patterns = [
-        [re.compile(u'[一ニ三四五六七八九十百千万億兆]'), 'M'],
+        [re.compile(u'[一二三四五六七八九十百千万億兆]'), 'M'],
         [re.compile(u'[一-龠々〆ヵヶ]'), 'H'],
         [re.compile(u'[ぁ-ん]'), 'I'],
         [re.compile(u'[ァ-ヴーｱ-ﾝﾞｰ]'), 'K'],

--- a/maker
+++ b/maker
@@ -226,7 +226,7 @@ def java(model):
     return template
 
 @language('tex', 'sty')
-def java(model):
+def tex(model):
 
     def tostr(category, values):
         result = ''


### PR DESCRIPTION
typo修正です。
カタカナのニを漢数字の二に修正など。
