### PR TITLE
Add Julia template

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -1,0 +1,9 @@
+using TinySegmenter
+
+f = open("timemachineu8j.txt")
+TinySegmenter.tokenize("プレコンパイル")
+s = join(readlines(f))
+
+@time for i in 1:100
+  TinySegmenter.tokenize(s)
+end

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -31,3 +31,8 @@ go run benchmark.go
 cp ../tinysegmenter.py ./tinysegmenter.py
 python --version
 python benchmark.py
+
+# Julia
+cp ../tinysegmenter.jl ./tinysegmenter.jl
+julia --version
+julia benchmark.jl

--- a/maker
+++ b/maker
@@ -409,6 +409,83 @@ def csharp(model):
     template = template.replace(u'__MODEL__', model_str).replace(u'__BIAS__', bias)
     return template
 
+@language('julia', 'jl')
+def julia(model):
+    def escape(key):
+        return key.replace(u'"', u'\\"')
+
+    def unigram2dict(obj):
+        items = []
+        for key, value in obj.items():
+            char = u"'" + key + u"'"
+            if key in [u'B1', u'B2', u'B3', u'E1', u'E2', u'E3']:
+                char = key
+            elif len(key) != 1:
+                continue
+            items.append(u"{0} => {1}".format(char, value))
+        items.sort()
+        return u'Dict{Char,Int}(' + u', '.join(items) + u')'
+
+    def asciingram2dict(obj, size):
+        items = []
+        for key, value in obj.items():
+            items.append(u"t\"{0}\" => {1}".format(key, value))
+        items.sort()
+        return 'Dict{Tuple{' + ','.join(['UInt8'] * size) + '},Int}('+ ', '.join(items) + ')'
+
+    def asciiunigram2dict(obj):
+        items = []
+        for key, value in obj.items():
+            if len(key) != 1:
+                continue
+            items.append(u"'{0}' => {1}".format(key, value))
+        items.sort()
+        return 'Dict{UInt8,Int}(' + ', '.join(items) + ')'
+
+    def ngram2dict(obj, size):
+        items = []
+        for key, value in obj.items():
+            chars = []
+            offset_flag = False
+            while len(key) != 0:
+                if len(key) != size and len(key) >= 2 and key[0:2] in ['B1', 'B2', 'B3', 'E1', 'E2', 'E3']:
+                    chars.append(key[0:2])
+                    key = key[2:]
+                    offset_flag = True
+                else:
+                    chars.append("'" + escape(key[0]) + "'")
+                    key = key[1:]
+            if len(chars) != size:
+                continue
+            if offset_flag:
+                items.append(u"({0}) => {1}".format(','.join(chars), value))
+                offset_flag = False
+            else:
+                items.append(u"t\"{0}\" => {1}".format(''.join([c.strip("'") for c in chars]), value))
+        items.sort()
+        return 'Dict{Tuple{' + ','.join(['Char'] * size) + '},Int}(' + ', '.join(items) + ')'
+
+    model_str = u"\nconst BIAS = {0}\n".format(model['BIAS'])
+    for key in ['UP1', 'UP2', 'UP3', 'UC1', 'UC2', 'UC3', 'UC4', 'UC5', 'UC6']:
+        model_str += "const " + key + " = " + asciiunigram2dict(model[key]) + "\n"
+    for key in ['BP1', 'BP2', 'BC1', 'BC2', 'BC3', 'UQ1', 'UQ2', 'UQ3']:
+        model_str += "const " + key + " = " + asciingram2dict(model[key], 2) + "\n"
+    for key in ['TC1', 'TC2', 'TC3', 'TC4', 'BQ1', 'BQ2', 'BQ3', 'BQ4']:
+        model_str += "const " + key + " = " + asciingram2dict(model[key], 3) + "\n"
+    for key in ['TQ1', 'TQ2', 'TQ3', 'TQ4']:
+        model_str += "const " + key + " = " + asciingram2dict(model[key], 4) + "\n"
+
+    for key in ['UW1', 'UW2', 'UW3', 'UW4', 'UW5', 'UW6']:
+        model_str += "const " + key + " = " + unigram2dict(model[key]) + "\n"
+    for key in ['BW1', 'BW2', 'BW3']:
+        model_str += "const " + key + " = " + ngram2dict(model[key], 2) + "\n"
+    for key in ['TW1', 'TW2', 'TW3', 'TW4']:
+        model_str += "const " + key + " = " + ngram2dict(model[key], 3) + "\n"
+
+    template = u(open('templates/julia.jl').read())
+    template = template.replace(u'__MODEL__', model_str)
+    return template
+
 def main():
     parser = OptionParser()
     parser.add_option("-s", "--scale", dest = "scale",

--- a/templates/julia.jl
+++ b/templates/julia.jl
@@ -1,0 +1,165 @@
+__precompile__()
+module TinySegmenter
+
+export tokenize
+
+typealias US UTF8String
+
+macro t_str(s)
+  tuple(s...)
+end
+
+# Use out of range of Unicode code point. See also: https://en.wikipedia.org/wiki/Code_point
+const B1 = Char(0x110001)
+const B2 = Char(0x110002)
+const B3 = Char(0x110003)
+const E1 = Char(0x110004)
+const E2 = Char(0x110005)
+
+__MODEL__
+
+const CHARDICT = Dict{Char, UInt8}()
+for (chars,cat) in (
+    ("一二三四五六七八九十百千万億兆",'M'),
+    ("々〆ヵヶ", 'H'),
+    ('ぁ':'ん','I'),
+    ('ァ':'ヴ','K'),
+    ("ーｰ\uff9e",'K'),
+    ('ｱ':'ﾝ','K'),
+    (['a':'z';'A':'Z';'ａ':'ｚ';'Ａ':'Ｚ'],'A'),
+    (['0':'9';'０':'９'],'N')
+  )
+  for c in chars
+      CHARDICT[c] = cat
+  end
+end
+const Achar = UInt8('A')
+const Ichar = UInt8('I')
+const Hchar = UInt8('H')
+const Ochar = UInt8('O')
+const Uchar = UInt8('U')
+const Bchar = UInt8('B')
+function ctype(c::Char)
+  return get(CHARDICT, c, '一' <= c <= '龠' ? Hchar : Ochar)
+end
+
+"""
+    tokenize(text::AbstractString)
+
+Given a `text` string, `tokenize` attempts to segment it into a list
+of words, and in particular tries to segment Japanese text
+into words ("tokens" or "segments"), using the TinySegmenter algorithm.
+It returns an array of substrings consisting of the guessed tokens in
+`text`, in the order that they appear.
+"""
+function tokenize{T<:AbstractString}(text::T)
+  result = SubString{T}[]
+  isempty(text) && return result
+
+  wordstart = start(text)
+  pos = wordstart
+
+  p1 = Uchar
+  p2 = Uchar
+  p3 = Uchar
+  w1, w2, w3 = B3, B2, B1
+  c1, c2, c3 = Ochar, Ochar, Ochar
+  w4 = text[pos]
+  c4 = ctype(w4)
+
+  pos1 = nextind(text, pos) # pos + 1 character
+  pos2 = nextind(text, pos1) # pos + 2 characters
+  if pos == endof(text)
+    w5, w6 = E1, E2
+    c5, c6 = Ochar, Ochar
+  else
+    w5 = text[pos1]
+    c5 = ctype(w5)
+    if pos1 == endof(text)
+      w6 = E1
+      c6 = Ochar
+    else
+      w6 = text[pos2]
+      c6 = ctype(w6)
+    end
+  end
+
+  while pos < endof(text)
+    score = BIAS
+    w1,w2,w3,w4,w5 = w2,w3,w4,w5,w6
+    c1,c2,c3,c4,c5 = c2,c3,c4,c5,c6
+    pos3 = nextind(text, pos2) # pos + 3
+    if pos3 <= endof(text)
+      w6 = text[pos3]
+      c6 = ctype(w6)
+    elseif pos2 == endof(text)
+      w6 = E1
+      c6 = Ochar
+    else # pos1 == endof(text)
+      w6 = E2
+      c6 = Ochar
+    end
+
+    if p1 == Ochar; score += -214; end # score += get(UP1, p1, 0)
+    if p2 == Bchar; score += 69; elseif p2 == Ochar; score += 935; end # score += get(UP2, p2, 0)
+    if p3 == Bchar; score += 189; end # score += get(UP3, p3, 0)
+    score += get(BP1, (p1, p2), 0)
+    score += get(BP2, (p2, p3), 0)
+    score += get(UW1, w1, 0)
+    score += get(UW2, w2, 0)
+    score += get(UW3, w3, 0)
+    score += get(UW4, w4, 0)
+    score += get(UW5, w5, 0)
+    score += get(UW6, w6, 0)
+    score += get(BW1, (w2, w3), 0)
+    score += get(BW2, (w3, w4), 0)
+    score += get(BW3, (w4, w5), 0)
+    score += get(TW1, (w1, w2, w3), 0)
+    score += get(TW2, (w2, w3, w4), 0)
+    score += get(TW3, (w3, w4, w5), 0)
+    score += get(TW4, (w4, w5, w6), 0)
+    score += get(UC1, c1, 0)
+    score += get(UC2, c2, 0)
+    if c3 == Achar; score += -1370; elseif c3 == Ichar; score += 2311; end # score += get(UC3, c3, 0)
+    score += get(UC4, c4, 0)
+    score += get(UC5, c5, 0)
+    score += get(UC6, c6, 0)
+    score += get(BC1, (c2, c3), 0)
+    score += get(BC2, (c3, c4), 0)
+    score += get(BC3, (c4, c5), 0)
+    score += get(TC1, (c1, c2, c3), 0)
+    score += get(TC2, (c2, c3, c4), 0)
+    score += get(TC3, (c3, c4, c5), 0)
+    score += get(TC4, (c4, c5, c6), 0)
+    score += get(UQ1, (p1, c1), 0)
+    score += get(UQ2, (p2, c2), 0)
+    score += get(UQ3, (p3, c3), 0)
+    score += get(BQ1, (p2, c2, c3), 0)
+    score += get(BQ2, (p2, c3, c4), 0)
+    score += get(BQ3, (p3, c2, c3), 0)
+    score += get(BQ4, (p3, c3, c4), 0)
+    score += get(TQ1, (p2, c1, c2, c3), 0)
+    score += get(TQ2, (p2, c2, c3, c4), 0)
+    score += get(TQ3, (p3, c1, c2, c3), 0)
+    score += get(TQ4, (p3, c2, c3, c4), 0)
+
+    p = Ochar
+    if score > 0
+      push!(result, SubString(text, wordstart, pos))
+      wordstart = pos1
+      p = Bchar
+    end
+
+    p1 = p2
+    p2 = p3
+    p3 = p
+    pos = pos1
+    pos1 = pos2
+    pos2 = pos3
+  end
+
+  push!(result, SubString(text, wordstart, pos))
+  return result
+end
+
+end # module


### PR DESCRIPTION
I implemented template of Julia version

I also benchmarked my environment.


|Ruby | C++ | Perl | Node.js | Go | Python |Python(tinysegmenter3) | Julia |
|---|---|---|---|---|---|---|---|
|132.98 | 48 | 134 |105.31 | 10.50 | 162.44 |111.85 | 11.70 |

```sh
+ cp ../tinysegmenter.rb ./tinysegmenter.rb
+ ruby --version
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin14]
+ ruby benchmark.rb
                 user     system      total        real
segment    131.780000   1.200000 132.980000 (133.858192)
+ cp ../tinysegmenter.hpp ./tinysegmenter.hpp
+ g++ -O3 -o benchmark benchmark.cpp
couldn't understand kern.osversion `15.0.0'
ld: warning: object file (/var/folders/gc/vtw38ncj07v80xwrxmclpnv00000gn/T//ccCLwJ3B.o) was built for newer OSX version (10.11) than being linked (10.4)
+ ./benchmark
48
+ cp ../tinysegmenter.pm ./tinysegmenter.pm
+ perl -I. benchmark.pl
134 sec
+ cp ../tinysegmenter.js ./tinysegmenter.js
+ node --version
v4.1.2
+ node benchmark.js
105.308sec
+ mkdir -p tinysegmenter
+ cp ../tinysegmenter.go tinysegmenter
+ go version
go version go1.5.1 darwin/amd64
+ go run benchmark.go
10.498139292s
+ cp ../tinysegmenter.py ./tinysegmenter.py
+ python --version
Python 3.5.0
+ python benchmark.py
elapsed_time:162.44142317771912[sec]
+ cp ../tinysegmenter.jl ./tinysegmenter.jl
+ julia4 --version
julia version 0.4.0
+ julia4 benchmark.jl
 11.701873 seconds (5.00 M allocations: 252.487 MB, 0.50% gc time)
```

BTW, another implementation of [Python version](https://github.com/SamuraiT/tinysegmenter) is faster (111.85 sec) than this implementation.